### PR TITLE
Grid class methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
 
 script:
-  - coverage run --source pygridtools check_pygridtools.py --cov --verbose --pep8
+  - python check_pygridtools.py --cov --verbose --pep8
 
 after_success:
   - if [ ${COVERAGE} = true ]; then

--- a/pygridtools/iotools.py
+++ b/pygridtools/iotools.py
@@ -176,8 +176,8 @@ def read_grid(shapefile, icol='ii', jcol='jj', othercols=None, expand=1,
 
     grid = (
         geopandas.read_file(shapefile)
-                 .rename(columns={icol: 'i', jcol: 'j'})
-                 .set_index(['i', 'j'])
+                 .rename(columns={icol: 'ii', jcol: 'jj'})
+                 .set_index(['ii', 'jj'])
                  .sort_index()
     )
     if as_gdf:
@@ -442,7 +442,7 @@ def _write_gridout_file(xcoords, ycoords, outfile):
     return df
 
 
-def _write_gridext_file(tidydf, outfile, icol='i', jcol='j',
+def _write_gridext_file(tidydf, outfile, icol='ii', jcol='jj',
                         xcol='easting', ycol='northing'):
     # make sure cols are in the right order
     df = tidydf[[icol, jcol, xcol, ycol]]

--- a/pygridtools/tests/test_core.py
+++ b/pygridtools/tests/test_core.py
@@ -352,8 +352,8 @@ def test_ModelGrid_template(g1):
 ])
 def test_ModelGrid_to_dataframe(g1, usemask, which, error):
     def name_cols(df):
-        df.columns.names = ['coord', 'i']
-        df.index.names = ['j']
+        df.columns.names = ['coord', 'ii']
+        df.index.names = ['jj']
         return df
 
     if error:

--- a/pygridtools/tests/test_iotools.py
+++ b/pygridtools/tests/test_iotools.py
@@ -195,8 +195,8 @@ def test_read_grid():
     result_df = iotools.read_grid(pntfile, othercols=['elev', 'river'])
     known_df = pandas.DataFrame(
         data={'easting': [1., 2., 3.] * 4, 'northing': sorted([4., 5., 6., 7.] * 3)},
-        index=pandas.MultiIndex.from_product([[2, 3, 4, 5], [2, 3, 4]], names=list('ji'))
-    ).assign(elev=0.0).assign(river='test').reset_index().set_index(['i', 'j']).sort_index()
+        index=pandas.MultiIndex.from_product([[2, 3, 4, 5], [2, 3, 4]], names=['jj', 'ii'])
+    ).assign(elev=0.0).assign(river='test').reset_index().set_index(['ii', 'jj']).sort_index()
 
     pdtest.assert_frame_equal(result_df, known_df)
 


### PR DESCRIPTION
Fixes the the `ModelGrid.from_xxx` class methods, updates cells masks, and standardizes to `icol='ii'` and `jcol='jj'`